### PR TITLE
Use the cancel_booking rpc in the supabase data implementation

### DIFF
--- a/pages/bookings/cancel/index.tsx
+++ b/pages/bookings/cancel/index.tsx
@@ -18,7 +18,7 @@ export default function CancelBooking() {
 
     try {
       if (booking_id) {
-        const success = await data.removeBooking(booking_id.toString());
+        const success = await data.cancelBooking(booking_id.toString());
 
         // Redirect if booking cancelled successfully
         if (success) {

--- a/shared/data/data.ts
+++ b/shared/data/data.ts
@@ -107,11 +107,11 @@ export interface DataAccessor {
   bookSlot(workshop_id: string, slot_id: string, user_id: string): Promise<boolean>
 
   /**
-   * Removes a booking with a given id
+   * Cancels a booking with a given id
    * @param id A booking id
    * @return A boolean representing the success of the method
    */
-  removeBooking(id: string): Promise<boolean>
+  cancelBooking(id: string): Promise<boolean>
 
   /**
    * Returns an avatar public URL given the path

--- a/shared/data/supabase.ts
+++ b/shared/data/supabase.ts
@@ -178,15 +178,13 @@ class SupabaseDataAccessor implements DataAccessor {
     return false;
   }
 
-  async removeBooking(id: string): Promise<boolean> {
-    const { error } = await supabase
-      .from("bookings")
-      .delete()
-      .match({ id: id });
-
+  async cancelBooking(id: string): Promise<boolean> {
+    const { data, error } = await supabase.rpc('cancel_booking', {
+      p_booking_id: id
+    })
     if (error) throw error;
 
-    return true;
+    return data ? true : false;
   }
 
   async getAvatarUrl(path: string): Promise<string> {


### PR DESCRIPTION
Since supabase doesn't support transactions we have created another postgres function that will transactionally delete the booking and mark it's slot as NOT at capacity so that future bookings can be made. See the function definition [here](https://github.com/share-platform/app-next/wiki/DatabaseSchema#cancel-booking).

Closes #24 
