### PR TITLE
Profile extension

### DIFF
--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -1,10 +1,12 @@
-import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { Box, Container, Flex, Heading, HStack, Text } from "@chakra-ui/react";
 import { useState, useEffect, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { auth } from "../shared/auth/supabase";
 import { data } from "../shared/data/supabase";
 import { User } from "../shared/schemas";
 import AccountAvatar from "./AccountAvatar";
+import { HiOutlineMail, HiUserGroup } from "react-icons/hi"
+import { dateToReadable } from "../utils/dates";
 
 export default function Account({ user }: { user: User }) {
   const [loading, setLoading] = useState(true);
@@ -16,7 +18,13 @@ export default function Account({ user }: { user: User }) {
     formState: { errors },
   } = useForm();
 
-  const { username, avatar_url } = watch();
+  const {
+    username,
+    avatar_url,
+    full_name,
+    member_since,
+    hosted_workshops
+  } = watch();
 
   const getProfile = useCallback(async () => {
     try {
@@ -32,6 +40,9 @@ export default function Account({ user }: { user: User }) {
       if (profile) {
         setValue("username", profile.username);
         setValue("avatar_url", profile.avatar_url);
+        setValue("full_name", `${profile.name} ${profile.surname}`);
+        setValue("member_since", profile.created_at);
+        setValue("hosted_workshops", profile.hosted_workshops);
       }
     } catch (error: any) {
       alert(`Error getting profile: ${error.message}`);
@@ -67,22 +78,31 @@ export default function Account({ user }: { user: User }) {
   }, [user, getProfile]);
 
   return (
-    <Box>
-      <Flex px={5} pt={5} pb={3} bg="white">
-        <AccountAvatar
-          url={avatar_url}
-          onUpload={(url: any) => {
-            setValue("avatar_url", url);
-            updateProfile({ avatar_url: url });
-          }}
-        />
-        <Flex flexDirection={"column"} justifyContent="center" ml={1}>
-          <Heading size={"md"}>{username}</Heading>
-          <Text size={"sm"} color={"gray.600"}>
-            {user?.email}
-          </Text>
+    <Container maxW="container.sm">
+      <Box>
+        <Flex px={5} pt={5} pb={3} bg="white">
+          <AccountAvatar
+            url={avatar_url}
+            onUpload={(url: any) => {
+              setValue("avatar_url", url);
+              updateProfile({ avatar_url: url });
+            }}
+          />
+          <Flex flexDirection={"column"} justifyContent="center" ml={1}>
+            <Heading size={"md"}>{full_name} (@{username})</Heading>
+            {/* <Heading size={"md"}>@{username}</Heading> */}
+            <Text size={"md"}>Member since {dateToReadable(member_since, false)}</Text>
+            <HStack spacing={2}>
+              <HiOutlineMail />
+              <Text size={"sm"} color={"gray.600"}>{user?.email}</Text>
+            </HStack>
+            <HStack spacing={2}>
+              <HiUserGroup />
+              <Text size={"sm"} color={"gray.600"}>Hosted {hosted_workshops} {hosted_workshops == 1 ? "Workshop" : "Workshops"}</Text>
+            </HStack>
+          </Flex>
         </Flex>
-      </Flex>
-    </Box>
+      </Box>
+    </Container>
   );
 }

--- a/components/AccountAvatar.tsx
+++ b/components/AccountAvatar.tsx
@@ -53,7 +53,7 @@ export default function AccountAvatar({ url, onUpload }: any) {
             borderRadius: "100%",
           }}
         >
-          {avatarUrl ? <Avatar size={"lg"} src={avatarUrl} /> : null}
+          {avatarUrl ? <Avatar size={"xl"} src={avatarUrl} /> : null}
         </FormLabel>
       </Box>
       <Box>

--- a/shared/data/supabase.ts
+++ b/shared/data/supabase.ts
@@ -45,6 +45,7 @@ class SupabaseDataAccessor implements DataAccessor {
     const { data, error } = await supabase.from("workshops").insert([workshop]);
     if (error) throw error;
     if (data) {
+      await supabase.rpc('increment_hosted_workshops', { id: workshop.user_id })
       return data[0] as Workshop;
     } else {
       throw Error(`Failed to create a workshop: ${JSON.stringify(workshop)}`);

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -28,6 +28,9 @@ export interface Profile {
   created_at?: number;
   user_id: string;
   username?: string;
+  name?: string;
+  surname?: string;
+  hosted_workshops?: number;
   avatar_url?: string;
 }
 

--- a/utils/dates.ts
+++ b/utils/dates.ts
@@ -1,10 +1,16 @@
-export function dateToReadable(date: string) {
-  const options = {
-    weekday: "long" as any,
-    year: "numeric" as any,
-    month: "long" as any,
-    day: "numeric" as any,
+export function dateToReadable(date: string, include_weekday: boolean = true) {
+  const options: {
+    weekday?: any,
+    year?: any,
+    month?: any,
+    day?: any
+  } = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
   };
+
+  if (include_weekday) options.weekday = "long";
 
   const dateObj = new Date(date);
 


### PR DESCRIPTION
The profile page now shows:
- [x] Full name
- [x] username
- [x] email
- [x] joined date
- [x] number of hosted workshops

![Screenshot from 2022-09-28 16-27-56](https://user-images.githubusercontent.com/16266257/192820897-0dd82928-ff06-42b2-987a-c48a3f14d553.png)
(click on image for full page view)

I decided to just show number of hosted workshops for now. It is stored as a field in the `profiles` table. I have also updated the [database schema](https://github.com/share-platform/app-next/wiki/DatabaseSchema) wiki page to reflect the addition of that column and documentation of additional two remote procedure calls for incrementing and decrementing this value. These RPCs are to be called when booking and cancelling the workshops respectively. I used RPCs because there is no way to increment this value with a single supabase call as we would need to first get the value and then write it.

Alternatively, we can check how many workshops are hosted by the user every time we are showing the profile page but that seems like an overkill, especially with the increasing number of workshops and users. Maintaining the hosted workshops counter seems like a more performant approach to me.

Any design and/or approach feedback is welcome.

Closes #33 