### PR TITLE
Display workshop location

### DIFF
--- a/components/Workshop/WorkshopForm.tsx
+++ b/components/Workshop/WorkshopForm.tsx
@@ -167,6 +167,18 @@ export default function WorkshopForm(): JSX.Element {
                     {errors.postcode && errors.postcode.message}
                   </FormErrorMessage>
                 </FormControl>
+
+                <FormControl>
+                  <Input
+                    {...register("city", {
+                      required: "This is required",
+                    })}
+                    placeholder="Bristol"
+                  />
+                  <FormErrorMessage>
+                    {errors.city && errors.city.message}
+                  </FormErrorMessage>
+                </FormControl>
               </>
             ) : null}
 

--- a/components/Workshop/WorkshopListingBody.tsx
+++ b/components/Workshop/WorkshopListingBody.tsx
@@ -1,7 +1,8 @@
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import React from "react";
-import { BsCameraVideo } from "react-icons/bs";
 import { Workshop } from "../../shared/schemas";
+import WorkshopListingBodyLocationVirtual from "./WorkshopListingBodyLocationVirtual";
+import WorkshopListingBodyLocationPhysical from "./WorkshopListingBodyLocationPhysical";
 
 interface IProps {
   workshop: Workshop;
@@ -10,35 +11,11 @@ interface IProps {
 export default function WorkshopListingBody({ workshop }: IProps) {
   return (
     <Box>
-      <Box color="gray.700" bg="gray.50" py="6" px={{ base: "2", md: "40" }}>
-        <Box
-          bg="white"
-          maxW={"300px"}
-          p="4"
-          rounded="md"
-          borderWidth={"1px"}
-          borderColor="gray.100"
-        >
-          <Flex alignItems={"center"}>
-            <Box mr="4" color="gray.500" fontSize={"25px"}>
-              <BsCameraVideo />
-            </Box>
-            <Box>
-              <Text
-                display={"flex"}
-                color={"black"}
-                alignItems="center"
-                fontSize={"14px"}
-              >
-                Online event
-              </Text>
-              <Text fontSize={"14px"} color={"gray.600"}>
-                Link visible for attendees
-              </Text>
-            </Box>
-          </Flex>
-        </Box>
-      </Box>
+      {
+        workshop.virtual
+        ? <WorkshopListingBodyLocationVirtual />
+        : <WorkshopListingBodyLocationPhysical workshop={workshop} />
+      }
       <Box px={{ base: "2", md: "40" }} py="6">
         <Text mb="1" fontWeight={"semibold"}>
           Details

--- a/components/Workshop/WorkshopListingBodyLocationPhysical.tsx
+++ b/components/Workshop/WorkshopListingBodyLocationPhysical.tsx
@@ -1,0 +1,42 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import React from "react";
+import { Workshop } from "../../shared/schemas";
+import { BsPinMap } from "react-icons/bs";
+
+interface IProps {
+  workshop: Workshop;
+}
+
+export default function WorkshopListingBody({ workshop }: IProps) {
+  return (
+    <Box color="gray.700" bg="gray.50" py="6" px={{ base: "2", md: "40" }}>
+        <Box
+          bg="white"
+          maxW={"300px"}
+          p="4"
+          rounded="md"
+          borderWidth={"1px"}
+          borderColor="gray.100"
+        >
+          <Flex alignItems={"center"}>
+            <Box mr="4" color="gray.500" fontSize={"25px"}>
+            <BsPinMap />
+            </Box>
+            <Box>
+              <Text
+                display={"flex"}
+                color={"black"}
+                alignItems="center"
+                fontSize={"14px"}
+              >
+                {workshop.house} {workshop.street}, {workshop.postcode}
+              </Text>
+              <Text fontSize={"14px"} color={"gray.600"}>
+                {workshop.city}
+              </Text>
+            </Box>
+          </Flex>
+        </Box>
+    </Box>
+  );
+}

--- a/components/Workshop/WorkshopListingBodyLocationVirtual.tsx
+++ b/components/Workshop/WorkshopListingBodyLocationVirtual.tsx
@@ -1,0 +1,37 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import React from "react";
+import { BsCameraVideo } from "react-icons/bs";
+
+export default function WorkshopListingBody() {
+  return (
+    <Box color="gray.700" bg="gray.50" py="6" px={{ base: "2", md: "40" }}>
+        <Box
+          bg="white"
+          maxW={"300px"}
+          p="4"
+          rounded="md"
+          borderWidth={"1px"}
+          borderColor="gray.100"
+        >
+          <Flex alignItems={"center"}>
+            <Box mr="4" color="gray.500" fontSize={"25px"}>
+              <BsCameraVideo />
+            </Box>
+            <Box>
+              <Text
+                display={"flex"}
+                color={"black"}
+                alignItems="center"
+                fontSize={"14px"}
+              >
+                Online event
+              </Text>
+              <Text fontSize={"14px"} color={"gray.600"}>
+                Link visible for attendees
+              </Text>
+            </Box>
+          </Flex>
+        </Box>
+    </Box>
+  );
+}

--- a/shared/schemas.ts
+++ b/shared/schemas.ts
@@ -18,9 +18,10 @@ export interface Workshop {
   user_id: string;
   description: string;
   category: string;
-  house: string;
-  street: string;
-  postcode: string;
+  house?: string;
+  street?: string;
+  postcode?: string;
+  city?: string;
   virtual: boolean;
 }
 


### PR DESCRIPTION
Whilst doing this I realsied that we are not storing a City name as part of the location for the workshop.
I have therefore included it in workshop table, updated the [Database Schema wiki](https://github.com/share-platform/app-next/wiki/DatabaseSchema) to reflect that and included it in the `WokrshopForm` so that it is collected when creating workshops.

We can now show both virtual 

![Screenshot from 2022-10-01 13-44-07](https://user-images.githubusercontent.com/16266257/193410277-2bffa95f-074d-4217-99b8-ddb516422868.png)

and physical locations in the `WorkshopListing` page.

![Screenshot from 2022-10-01 13-44-00](https://user-images.githubusercontent.com/16266257/193410275-feb724b6-d297-4295-8964-65dd88f350bd.png)


Closes #31 